### PR TITLE
Add test utility for sending test telemetry into AppInsights

### DIFF
--- a/src/ResourceManagementTests/ResourceManagementTests.csproj
+++ b/src/ResourceManagementTests/ResourceManagementTests.csproj
@@ -17,6 +17,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\TestUtility\TestUtility.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Using Include="Xunit" />
   </ItemGroup>
 

--- a/src/ResourceManagementTests/UnitTest1.cs
+++ b/src/ResourceManagementTests/UnitTest1.cs
@@ -1,10 +1,22 @@
+using TestUtility;
+using Xunit.Abstractions;
+
 namespace ResourceManagementTests
 {
-    public class UnitTest1
+    public class UnitTest1 : TestBase
     {
+        public UnitTest1(ITestOutputHelper output)
+            : base(output)
+        {
+        }
+
         [Fact]
         public void Test1()
         {
+            string uniqueString = Guid.NewGuid().ToString();
+            Logger.Information("This is a test log message. " + uniqueString);
+            var logEvents = GetLogEvents();
+            Assert.True(logEvents.Any(e => e.MessageTemplate.Text.Contains(uniqueString)), "Log message should contain the unique string.");
             Assert.True(true, "This test should always pass.");
         }
     }

--- a/src/ResourceManagementTests/UnitTest1.cs
+++ b/src/ResourceManagementTests/UnitTest1.cs
@@ -11,10 +11,18 @@ namespace ResourceManagementTests
         }
 
         [Fact]
-        public void Test1()
+        public async Task Test1()
         {
             string uniqueString = Guid.NewGuid().ToString();
             Logger.Information("This is a test log message. " + uniqueString);
+
+            try
+            {
+                HttpClient client = new HttpClient();
+                await client.GetAsync($"https://invalid-domain-value-{uniqueString}.com");
+            }
+            catch { }
+
             var logEvents = GetLogEvents();
             Assert.True(logEvents.Any(e => e.MessageTemplate.Text.Contains(uniqueString)), "Log message should contain the unique string.");
             Assert.True(true, "This test should always pass.");

--- a/src/TestUtility/TestBase.cs
+++ b/src/TestUtility/TestBase.cs
@@ -130,16 +130,21 @@ namespace TestUtility
 
         private void GenerateLogger(string testClass, bool useAppInsights, ITestOutputHelper output = null)
         {
-            var loggerConfig = new LoggerConfiguration()
-                .Enrich.WithProperty("TestClassName", testClass)
-                .Enrich.WithProperty("UnitTestessionId", Guid.NewGuid().ToString())
-                .Enrich.WithProperty("UnitTestStartTime", DateTime.UtcNow.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture));
+            UnitTestSessionContext unitTestSessionContext = new UnitTestSessionContext()
+            {
+                TestClassName = testClass,
+            };
+
+            var loggerConfig = new LoggerConfiguration();
 
             loggerConfig = loggerConfig.WriteTo.TestCorrelator();
 
             if (useAppInsights)
             {
                 var builder = _appInsightsConfig.TelemetryProcessorChainBuilder;
+
+                _appInsightsConfig.TelemetryInitializers.Add(new UnitTestSessionTelemetryInitializer(unitTestSessionContext));
+
                 builder.Build();
 
                 _depModule = new DependencyTrackingTelemetryModule();

--- a/src/TestUtility/TestBase.cs
+++ b/src/TestUtility/TestBase.cs
@@ -1,11 +1,95 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using Serilog.Sinks.TestCorrelator;
+using Serilog;
+using System;
+using System.Globalization;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Xunit.Abstractions;
+using Microsoft.ApplicationInsights.DependencyCollector;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Extensibility;
 
 namespace TestUtility
 {
     public class TestBase
     {
+        private readonly TelemetryConfiguration _appInsightsConfig = new TelemetryConfiguration()
+        {
+            ConnectionString = "InstrumentationKey=325fe9df-8b9a-412c-8f5d-fc268414d6ab;IngestionEndpoint=https://westus2-2.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/;ApplicationId=c17a4dee-fc11-44bd-81f7-597c85d453c3",
+        };
+        private DependencyTrackingTelemetryModule _depModule;
+        private TelemetryClient _appInsightsClient;
+        private bool _disposed = false;
+        private readonly ITestCorrelatorContext _testCorrelatorContext;
 
+        public TestBase(ITestOutputHelper output, bool useAppInsights = false, [CallerFilePath] string sourceFile = "")
+        {
+            if (output == null)
+            {
+                throw new ArgumentNullException(nameof(output));
+            }
+
+            TestExceptionHelper.Register(sourceFile);
+            string testClass = GetType().Name;
+            GenerateLogger(testClass, useAppInsights, output);
+            _testCorrelatorContext = TestCorrelator.CreateContext();
+            string operationName = null;
+
+            try
+            {
+                var testOutputType = output.GetType();
+                FieldInfo cachedTestMember = testOutputType.GetField("test", BindingFlags.Instance | BindingFlags.NonPublic);
+                if (cachedTestMember != null)
+                {
+                    Test = (ITest)cachedTestMember.GetValue(output);
+
+
+                    string[] parts = Test.DisplayName.Split('.');
+                    TestClassName = parts[parts.Length - 2];
+                    TestMethodName = parts[parts.Length - 1];
+                }
+            }
+            catch
+            {
+                operationName = testClass;
+            }
+        }
+
+        public ITest Test { get; }
+
+        public ILogger Logger { get; private set; }
+
+        public string TestClassName { get; }
+
+        public string TestMethodName { get; }
+
+        private void GenerateLogger(string testClass, bool useAppInsights, ITestOutputHelper output = null)
+        {
+            var loggerConfig = new LoggerConfiguration()
+                .Enrich.WithProperty("TestClassName", testClass)
+                .Enrich.WithProperty("UnitTestessionId", Guid.NewGuid().ToString())
+                .Enrich.WithProperty("UnitTestStartTime", DateTime.UtcNow.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture));
+
+            loggerConfig = loggerConfig.WriteTo.TestCorrelator();
+
+            if (useAppInsights)
+            {
+                var builder = _appInsightsConfig.TelemetryProcessorChainBuilder;
+                builder.Build();
+
+                _depModule = new DependencyTrackingTelemetryModule();
+                _depModule.Initialize(_appInsightsConfig);
+                _appInsightsClient = new TelemetryClient(_appInsightsConfig);
+
+                loggerConfig = loggerConfig.WriteTo.ApplicationInsights(_appInsightsClient, TelemetryConverter.Events);
+            }
+
+            if (output != null)
+            {
+                loggerConfig = loggerConfig.WriteTo.Xunit(output);
+            }
+
+            Logger = loggerConfig.Enrich.FromLogContext().CreateLogger();
+        }
     }
 }

--- a/src/TestUtility/TestBase.cs
+++ b/src/TestUtility/TestBase.cs
@@ -6,5 +6,6 @@ namespace TestUtility
 {
     public class TestBase
     {
+
     }
 }

--- a/src/TestUtility/TestBase.cs
+++ b/src/TestUtility/TestBase.cs
@@ -8,10 +8,12 @@ using Xunit.Abstractions;
 using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.Extensibility;
+using System.Linq;
+using System.Threading;
 
 namespace TestUtility
 {
-    public class TestBase
+    public class TestBase : IDisposable
     {
         private readonly TelemetryConfiguration _appInsightsConfig = new TelemetryConfiguration()
         {
@@ -22,7 +24,12 @@ namespace TestUtility
         private bool _disposed = false;
         private readonly ITestCorrelatorContext _testCorrelatorContext;
 
-        public TestBase(ITestOutputHelper output, bool useAppInsights = false, [CallerFilePath] string sourceFile = "")
+        static TestBase()
+        {
+            TestExceptionHelper.EnableExceptionCapture();
+        }
+
+        public TestBase(ITestOutputHelper output, bool useAppInsights = true, [CallerFilePath] string sourceFile = "")
         {
             if (output == null)
             {
@@ -62,6 +69,64 @@ namespace TestUtility
         public string TestClassName { get; }
 
         public string TestMethodName { get; }
+
+        public bool? IsFailure { get; private set; }
+
+        public Serilog.Events.LogEvent[] GetLogEvents() => TestCorrelator.GetLogEventsFromContextGuid(_testCorrelatorContext.Guid).ToArray();
+
+        public void CheckLogPrefix(string expectingLogPrefic, int count = 1)
+        {
+            var logs = GetLogEvents();
+            int matchingCount = logs.Count(l => l.MessageTemplate.Text.StartsWith(expectingLogPrefic, StringComparison.OrdinalIgnoreCase));
+            if (matchingCount != count)
+            {
+                throw new InvalidOperationException($"There should be {count} of the log prefix, however there are {matchingCount} in actual. log prefix: {expectingLogPrefic}");
+            }
+        }
+
+        public virtual void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            try
+            {
+                var theExceptionThrownByTest = TestExceptionHelper.TestException;
+                if (theExceptionThrownByTest != null)
+                {
+                    IsFailure = true;
+                    Logger.Error(theExceptionThrownByTest, $"test_failure. {TestClassName}");
+                }
+                else
+                {
+                    IsFailure = false;
+                }
+
+
+                _testCorrelatorContext.Dispose();
+
+                if (_appInsightsClient != null)
+                {
+                    _appInsightsClient?.Flush();
+                    _appInsightsConfig?.Dispose();
+                    _depModule?.Dispose();
+
+                    // Wait while the telemetry data is being flushed
+                    Thread.Sleep(3000);
+                }
+
+                _appInsightsClient = null;
+                _depModule = null;
+            }
+            catch
+            {
+            }
+        }
+
 
         private void GenerateLogger(string testClass, bool useAppInsights, ITestOutputHelper output = null)
         {

--- a/src/TestUtility/TestContext.cs
+++ b/src/TestUtility/TestContext.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using Xunit.Sdk;
+
+namespace TestUtility
+{
+    /// <summary>
+    ///  https://github.com/SimonCropp/XunitContext/blob/master/src/XunitContext/Context.cs
+    /// </summary>
+    internal class TestContext
+    {
+        internal Exception _exception;
+
+        internal TestContext(string sourceFile)
+        {
+            SourceFile = sourceFile;
+        }
+
+        internal TestContext()
+        {
+        }
+
+        /// <summary>
+        /// The source file that the current test exists in.
+        ///
+        /// </summary>
+        public string SourceFile { get; internal set; } = null;
+
+        /// <summary>
+        /// The <see cref="_exception"/> for the current test if it failed.
+        /// </summary>
+        public Exception TestException
+        {
+            get
+            {
+                if (_exception == null)
+                {
+                    return null;
+                }
+
+                if (_exception is XunitException)
+                {
+                    return _exception;
+                }
+
+                var outerTrace = new StackTrace(_exception, false);
+                var firstFrame = outerTrace.GetFrame(outerTrace.FrameCount - 1);
+                var firstMethod = firstFrame.GetMethod();
+
+                var root = firstMethod.DeclaringType.DeclaringType;
+                if (root != null && root == typeof(ExceptionAggregator))
+                {
+                    if (_exception is TargetInvocationException targetInvocationException)
+                    {
+                        return targetInvocationException.InnerException;
+                    }
+
+                    return _exception;
+                }
+
+                return null;
+            }
+        }
+    }
+}

--- a/src/TestUtility/TestExceptionHelper.cs
+++ b/src/TestUtility/TestExceptionHelper.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace TestUtility
+{
+    /// <summary>
+    /// https://github.com/SimonCropp/XunitContext/blob/master/src/XunitContext/XunitContext.cs
+    /// </summary>
+    internal static class TestExceptionHelper
+    {
+        private static AsyncLocal<TestContext> s_local = new AsyncLocal<TestContext>();
+
+        private static bool s_enableExceptionCapture;
+
+        /// <summary>
+        /// The <see cref="Exception"/> for the current test if it failed.
+        /// </summary>
+        public static Exception TestException => s_local.Value?.TestException;
+
+        public static void EnableExceptionCapture()
+        {
+            if (s_enableExceptionCapture)
+            {
+                return;
+            }
+
+            s_enableExceptionCapture = true;
+            AppDomain.CurrentDomain.FirstChanceException += (sender, e) =>
+            {
+                if (s_local.Value == null)
+                {
+                    return;
+                }
+
+                s_local.Value._exception = e.Exception;
+            };
+        }
+
+        public static TestContext Register([CallerFilePath] string sourceFile = "")
+        {
+            var existingContext = s_local.Value;
+
+            if (existingContext == null)
+            {
+                var context = new TestContext(sourceFile);
+                s_local.Value = context;
+                return context;
+            }
+
+            existingContext.SourceFile = sourceFile;
+            return existingContext;
+        }
+    }
+}

--- a/src/TestUtility/TestUtility.csproj
+++ b/src/TestUtility/TestUtility.csproj
@@ -4,4 +4,13 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.21.0" />
+    <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="3.2.0" />
+    <PackageReference Include="Serilog.Sinks.Xunit2" Version="1.0.0" />
+    <PackageReference Include="xunit.assert" Version="2.4.2" />
+    <PackageReference Include="xunit.extensibility.execution" Version="2.4.2" />
+  </ItemGroup>
+
 </Project>

--- a/src/TestUtility/UnitTestSessionContext.cs
+++ b/src/TestUtility/UnitTestSessionContext.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Globalization;
+
+namespace TestUtility
+{
+    public class UnitTestSessionContext
+    {
+        public string TestClassName { get; set; }
+
+        public string UnitTestessionId { get; set; } = Guid.NewGuid().ToString();
+
+        public string UnitTestStartTime { get; set; } = DateTime.UtcNow.ToUniversalTime().ToString("o", CultureInfo.InvariantCulture);
+    }
+}

--- a/src/TestUtility/UnitTestSessionTelemetryInitializer.cs
+++ b/src/TestUtility/UnitTestSessionTelemetryInitializer.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using System;
+
+namespace TestUtility
+{
+    public class UnitTestSessionTelemetryInitializer : ITelemetryInitializer
+    {
+        private readonly UnitTestSessionContext _unitTestSessionContext;
+
+        public UnitTestSessionTelemetryInitializer(UnitTestSessionContext unitTestSessionContext)
+        {
+            _unitTestSessionContext = unitTestSessionContext ?? throw new ArgumentNullException(nameof(unitTestSessionContext));
+        }
+
+        public void Initialize(ITelemetry telemetry)
+        {
+            if (telemetry is ISupportProperties propertyItem && propertyItem.Properties != null)
+            {
+                if (!string.IsNullOrEmpty(_unitTestSessionContext.TestClassName))
+                {
+                    propertyItem.Properties[nameof(_unitTestSessionContext.TestClassName)] = _unitTestSessionContext.TestClassName;
+                }
+
+                if (!string.IsNullOrEmpty(_unitTestSessionContext.UnitTestessionId))
+                {
+                    propertyItem.Properties[nameof(_unitTestSessionContext.UnitTestessionId)] = _unitTestSessionContext.UnitTestessionId;
+                }
+
+                if (!string.IsNullOrEmpty(_unitTestSessionContext.UnitTestStartTime))
+                {
+                    propertyItem.Properties[nameof(_unitTestSessionContext.UnitTestStartTime)] = _unitTestSessionContext.UnitTestStartTime;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add test utility for sending test telemetry into AppInsights. Then we can do analyze of the test failures.

![image](https://github.com/user-attachments/assets/da75cd41-7b51-4701-b06f-18fca266e595)

![image](https://github.com/user-attachments/assets/2b2285b9-9eeb-4834-8073-28b903c0207d)
